### PR TITLE
Remove "clang" statement

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -12,7 +12,6 @@ cc_defaults {
         "libutils",
     ],
     header_libs: ["display_headers"],
-    clang: true,
 }
 
 cc_library_headers {


### PR DESCRIPTION
not supported on android 14